### PR TITLE
Replace npm ci for npm install 

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -26,9 +26,7 @@ jobs:
           aws-region: us-east-2
 
       - name: Install dependencies
-        env:
-          CI: true
-        run: npm ci
+        run: npm install
 
 
       - name: Deploy to Lambda


### PR DESCRIPTION
This because project does not have the required package-lock.json file